### PR TITLE
Reformat long lines to 79 characters in Python scripts

### DIFF
--- a/build-data/osx/dmgsettings.py
+++ b/build-data/osx/dmgsettings.py
@@ -8,7 +8,7 @@ import os.path
 # beneit of linting tools.
 defines = defines  # noqa: F821
 
-# .. Useful stuff ..............................................................
+# .. Useful stuff .............................................................
 
 application = defines.get('app', 'Cataclysm.app')
 appname = os.path.basename(application)
@@ -25,7 +25,7 @@ def icon_from_app(app_path):
     return os.path.join(app_path, 'Contents', 'Resources', icon_name)
 
 
-# .. Basics ....................................................................
+# .. Basics ...................................................................
 
 # Uncomment to override the output filename
 # filename = 'test.dmg'
@@ -47,9 +47,9 @@ symlinks = {'Applications': '/Applications'}
 
 # Volume icon
 #
-# You can either define icon, in which case that icon file will be copied to the
-# image, *or* you can define badge_icon, in which case the icon file you specify
-# will be used to badge the system's Removable Disk icon
+# You can either define icon, in which case that icon file will be copied to
+# the image, *or* you can define badge_icon, in which case the icon file you
+# specify will be used to badge the system's Removable Disk icon
 #
 #icon = '/path/to/icon.icns'
 badge_icon = icon_from_app(application)
@@ -60,7 +60,7 @@ icon_locations = {
     'Applications': (430, 400)
 }
 
-# .. Window configuration ......................................................
+# .. Window configuration .....................................................
 
 # Background
 #
@@ -111,7 +111,7 @@ show_icon_preview = False
 include_icon_view_settings = 'auto'
 include_list_view_settings = 'auto'
 
-# .. Icon view configuration ...................................................
+# .. Icon view configuration ..................................................
 
 arrange_by = None
 grid_offset = (0, 0)
@@ -121,7 +121,7 @@ label_pos = 'bottom'  # or 'right'
 text_size = 16
 icon_size = 64
 
-# .. List view configuration ...................................................
+# .. List view configuration ..................................................
 
 # Column names are as follows:
 #

--- a/tools/gfx_tools/png_update.py
+++ b/tools/gfx_tools/png_update.py
@@ -3,6 +3,10 @@
 # png_update.py
 # Rename a png and update all references to it.
 
+"""Rename a png file, its associated tile_entry.json, and update all
+other tile_entry.json in the tileset dir to reflect the new name.
+"""
+
 import argparse
 import json
 import os
@@ -65,18 +69,21 @@ def convert_tile_entry(tile_entry, old_name, new_name):
     changed = False
     old_fg_id = tile_entry.get("fg", [])
     if old_fg_id:
-        tile_entry["fg"], fg_changed = convert_index(old_fg_id, old_name, new_name)
+        tile_entry["fg"], fg_changed = convert_index(
+            old_fg_id, old_name, new_name)
         changed = fg_changed
 
     old_bg_id = tile_entry.get("bg", [])
     if old_bg_id:
-        tile_entry["bg"], bg_changed = convert_index(old_bg_id, old_name, new_name)
+        tile_entry["bg"], bg_changed = convert_index(
+            old_bg_id, old_name, new_name)
         changed |= bg_changed
 
     add_tile_entrys = tile_entry.get("additional_tiles", [])
     new_tile_entrys = []
     for add_tile_entry in add_tile_entrys:
-        changed_tile_entry, add_changed = convert_tile_entry(add_tile_entry, old_name, new_name)
+        changed_tile_entry, add_changed = convert_tile_entry(
+            add_tile_entry, old_name, new_name)
         new_tile_entrys.append(changed_tile_entry)
         changed |= add_changed
     if new_tile_entrys:
@@ -93,7 +100,8 @@ def convert_tile_entry_file(file_path, old_name, new_name):
     if not isinstance(tile_data, list):
         tile_data = [tile_data]
     for tile_entry in tile_data:
-        new_entry, entry_changed = convert_tile_entry(tile_entry, old_name, new_name)
+        new_entry, entry_changed = convert_tile_entry(
+            tile_entry, old_name, new_name)
         new_tile_data.append(new_entry)
         changed = entry_changed or changed
     if changed:
@@ -103,7 +111,7 @@ def convert_tile_entry_file(file_path, old_name, new_name):
 
 
 if __name__ == '__main__':
-    args = argparse.ArgumentParser(description="Rename a png file, its associated tile_entry.json, and update all other tile_entry.json in the tileset dir to reflect the new name.")
+    args = argparse.ArgumentParser(description=__doc__)
     args.add_argument("tileset_dir", action="store",
                       help="local name of the tileset directory under gfx/")
     args.add_argument("old_name", action="store",
@@ -133,7 +141,8 @@ if __name__ == '__main__':
     if tileset_dirname.endswith("/"):
         tileset_dirname = tileset_dirname[:-1]
 
-    print("In " + tileset_dirname + ", renaming " + old_name + " to " + new_name)
+    print("In " + tileset_dirname + ", renaming " +
+          old_name + " to " + new_name)
     for png_dirname in os.listdir(tileset_dirname):
         if not png_dirname.startswith("pngs_"):
             continue

--- a/tools/json_tools/cddatags.py
+++ b/tools/json_tools/cddatags.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+"""Update a tags file with locations of the definitions of CDDA json entities.
+
+If you already have a tags file with some data in, this will only
+replace tags in json files, not e.g. cpp files, so it should be safe
+to use after running e.g. ctags.
+"""
 
 import argparse
 import json
@@ -21,16 +27,16 @@ def is_json_tag_line(line):
 
 
 def main(args):
-    parser = argparse.ArgumentParser(description="""
-Update a tags file with locations of the definitions of CDDA json entities.
-
-If you already have a tags file with some data in, this will only replace tags
-in json files, not e.g. cpp files, so it should be safe to use after running
-e.g. ctags.""")
+    parser = argparse.ArgumentParser(description=__doc__)
 
     parser.parse_args(args)
 
     definitions = []
+
+    # JSON keys to generate tags for
+    id_keys = (
+        'id', 'abstract', 'ident',
+        'nested_mapgen_id', 'update_mapgen_id', 'result')
 
     for dirpath, dirnames, filenames in os.walk(JSON_DIR):
         for filename in filenames:
@@ -54,13 +60,14 @@ e.g. ctags.""")
                             "expected a list." % filename)
                         continue
 
+                    # Check each object in json_data for taggable keys
                     for obj in json_data:
-                        for id_key in ('id', 'abstract', 'ident',
-                                       'nested_mapgen_id', 'update_mapgen_id', 'result'):
+                        for id_key in id_keys:
                             if id_key in obj:
                                 id = obj[id_key]
                                 if type(id) == str and id:
-                                    definitions.append((id_key, id, relative_path))
+                                    definitions.append(
+                                        (id_key, id, relative_path))
 
     json_tags_lines = [make_tags_line(*d) for d in definitions]
     existing_tags_lines = []

--- a/tools/json_tools/keys.py
+++ b/tools/json_tools/keys.py
@@ -1,14 +1,5 @@
 #!/usr/bin/env python3
-"""Run this script with -h for usage info and docs.
-"""
-
-import sys
-import json
-import argparse
-from util import import_data, key_counter, ui_counts_to_columns,\
-    WhereAction
-
-parser = argparse.ArgumentParser(description="""Count the number of times a specific key occurs.
+"""Count the number of times a specific key occurs.
 
 Example usages:
 
@@ -17,7 +8,17 @@ Example usages:
 
     # List keys on JSON objects of type "bionic", output in JSON.
     %(prog)s type=bionic
-""", formatter_class=argparse.RawDescriptionHelpFormatter)
+
+"""
+
+import sys
+import json
+import argparse
+from util import import_data, key_counter, ui_counts_to_columns,\
+    WhereAction
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
 parser.add_argument(
     "--fnmatch",
@@ -26,7 +27,7 @@ parser.add_argument(
 parser.add_argument(
     "-H", "--human",
     action="store_true",
-    help="if set, makes output human readable. default is to return output in JSON.")
+    help="if set, makes output human readable. default is JSON output.")
 parser.add_argument(
     "-L", "--list",
     action="store_true",

--- a/tools/json_tools/lister.py
+++ b/tools/json_tools/lister.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
-"""Run this script with -h for usage info and docs.
+"""Make a distinct list of keys from JSON input.
+
+Main purpose to take output from other scripts, which will be JSON
+dictionaries or lists of JSON dictionaries and get a distinct set of
+keys from all the items.
+
+Can be used to answer questions like, "What types of material are on
+the items?" when all you want to know is types, not counts.
+
+Example usages:
+
+    values.py -k material | %(prog)s
+
 """
 
 import argparse
@@ -9,34 +21,26 @@ import json
 import sys
 from util import ui_values_to_columns
 
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
-parser = argparse.ArgumentParser(description="""Make a distinct list of keys from JSON input.
-Main purpose to take output from other scripts, which will be JSON dictionaries or lists
-of JSON dictionaries and get a distinct set of keys from all the items.
-
-Can be used to answer questions like, "What types of material are on the items?" when
-all you want to know is types, not counts.
-
-Example usages:
-
-    values.py -k material | %(prog)s
-
-""", formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument(
     "--human",
     action="store_true",
-    help="if set, makes output human readable. default is to return output in JSON.")
+    help="if set, makes output human readable. default is JSON output.")
 
 
 if __name__ == "__main__":
     args = parser.parse_args()
 
     # Saw this trick here:
-    # http://stackoverflow.com/questions/13442574/how-do-i-determine-if-sys-stdin-is-redirected-from-a-file-vs-piped-from-another
+    # http://stackoverflow.com/questions/13442574/how-do-i-determine-if-
+    #     sys-stdin-is-redirected-from-a-file-vs-piped-from-another
     mode = os.fstat(0).st_mode
     if not stat.S_ISFIFO(mode) and not stat.S_ISREG(mode):
         # input is terminal, not what we want
-        print("Redirect data to stdin, please (e.g. with a pipe). -h for usage.")
+        print("Redirect data to stdin, please (e.g. with a pipe)."
+              " Run with -h for usage.")
         sys.exit(1)
 
     try:

--- a/tools/json_tools/pluck.py
+++ b/tools/json_tools/pluck.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
-"""Run this script with -h for usage info and docs.
-"""
-
-import sys
-import argparse
-from util import import_data, matches_all_wheres, CDDAJSONWriter, WhereAction
-
-parser = argparse.ArgumentParser(description="""Search for matches within the json data.
+"""Search for matches within the json data.
 
 Example usages:
 
     %(prog)s --all type=dream strength=2
 
     %(prog)s material=plastic material=steel
-""", formatter_class=argparse.RawDescriptionHelpFormatter)
+
+"""
+
+import sys
+import argparse
+from util import import_data, matches_all_wheres, CDDAJSONWriter, WhereAction
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument(
     "--fnmatch",
     default="*.json",
@@ -21,7 +22,7 @@ parser.add_argument(
 parser.add_argument(
     "--all",
     action="store_true",
-    help="if set, includes all matches. if not set, includes first match in the stream.")
+    help="includes all matches. by default, include only the first match.")
 parser.add_argument(
     "where",
     action=WhereAction, nargs='+', type=str,
@@ -45,7 +46,8 @@ if __name__ == "__main__":
 
     # Wasteful iteration, but less code to maintain on a tool that will likely
     # change again.
-    plucked = [item for item in json_data if matches_all_wheres(item, args.where)]
+    plucked = [
+        item for item in json_data if matches_all_wheres(item, args.where)]
 
     if not plucked:
         print("Nothing found.")

--- a/tools/json_tools/pocket_mags.py
+++ b/tools/json_tools/pocket_mags.py
@@ -20,7 +20,8 @@ def gen_new(path):
                 if "ammo_type" in jo:
                     pocket_data = [{
                         "pocket_type": "MAGAZINE",
-                        "ammo_restriction": {k: jo["capacity"] for k in jo["ammo_type"]}
+                        "ammo_restriction": {k: jo["capacity"]
+                                             for k in jo["ammo_type"]}
                     }]
                     jo["pocket_data"] = pocket_data
                     change = True

--- a/tools/json_tools/recipe_activity.py
+++ b/tools/json_tools/recipe_activity.py
@@ -7,7 +7,8 @@ import os
 args = argparse.ArgumentParser()
 args.add_argument("dir", action="store", help="specify json directory")
 args.add_argument("id", action="store", help="id of recipe to adjust")
-args.add_argument("level", action="store", help="what activity level to shift it to")
+args.add_argument("level", action="store",
+                  help="what activity level to shift it to")
 args_dict = vars(args.parse_args())
 
 
@@ -40,7 +41,9 @@ def gen_new(path):
             if jo["result"] == args_dict["id"]:
                 # Already got this one
                 if jo["activity_level"] != "fake":
-                    print("skipping {skipped} - value is {val}, currently on {current}".format(skipped=jo["result"], val=jo["activity_level"], current=args_dict["id"]))
+                    print("skipping {}".format(jo["result"]) +
+                          " - value is {},".format(jo["activity_level"]) +
+                          " currently on {}".format(args_dict["id"]))
                     return None
                 jo["activity_level"] = args_dict["level"]
                 change = True

--- a/tools/json_tools/splitter.py
+++ b/tools/json_tools/splitter.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
-"""Run this script with -h for usage info and docs.
+"""Taking a filtered list of JSON data, look for all items that
+match the where clause and output to stdout. All items that don't
+match are output to stderr.
+
+Example usages:
+
+    # Anything of type dream and strength 2 goes to stdout
+    # everything else goes to stderr
+    %(prog)s --fnmatch=dreams.json type=dream strength=2 \\
+        1>matched.json 2>not_matched.json
+
 """
 
 import sys
 import argparse
 from util import import_data, matches_all_wheres, CDDAJSONWriter, WhereAction
 
-parser = argparse.ArgumentParser(description="""Taking a filtered list of JSON data,
-look for all items that match the where clause and output to stdout. All items
-that don't match are output to stderr.
-
-Example usages:
-
-    # Anything of type dream and strength 2 goes to stdout
-    # everything else goes to stderr
-    %(prog)s --fnmatch=dreams.json type=dream strength=2 1>matched.json 2>not_matched.json
-""", formatter_class=argparse.RawDescriptionHelpFormatter)
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument(
     "--fnmatch",
     default="*.json",

--- a/tools/json_tools/table.py
+++ b/tools/json_tools/table.py
@@ -73,7 +73,8 @@ def item_values(item, fields, none_string="None"):
         ...             ['name', 'length_cm'])
         ['sword', '90']
 
-    Fields may also be nested objects; subkeys may be referenced like key.subkey:
+    Fields may also be nested objects; subkeys may be referenced like
+    key.subkey:
 
         >>> item_values({'loc': {'x': 5, 'y': 10}}, ['loc.x', 'loc.y'])
         ['5', '10']
@@ -208,7 +209,8 @@ class CDDAValues:
         format_class = get_format_class_by_extension(format_string)
         self.output = format_class()
 
-    def print_table(self, data, columns, types_filter, none_string, with_header):
+    def print_table(self, data, columns, types_filter,
+                    none_string, with_header):
         if with_header:
             self.output.header(columns)
         for item in data:

--- a/tools/json_tools/util.py
+++ b/tools/json_tools/util.py
@@ -11,15 +11,17 @@ from io import StringIO
 
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
-JSON_DIR = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "..", "data", "json"))
+JSON_DIR = os.path.normpath(
+    os.path.join(SCRIPT_DIR, "..", "..", "data", "json"))
 JSON_FNMATCH = "*.json"
 
 
 def import_data(json_dir=JSON_DIR, json_fmatch=JSON_FNMATCH):
     """Use a UNIX like file match expression to weed out the JSON files.
 
-    returns tuple, first element containing json read, second element containing
-    list of any errors found. error list will be empty if no errors
+    returns tuple, first element containing json read, second element
+    containing list of any errors found. error list will be empty if
+    no errors
     """
     data = []
     errors = []
@@ -31,14 +33,20 @@ def import_data(json_dir=JSON_DIR, json_fmatch=JSON_FNMATCH):
                 json_file = os.path.join(d, f)
                 with open(json_file, "r") as file:
                     try:
-                        candidates = json.load(file, object_pairs_hook=OrderedDict)
+                        candidates = json.load(
+                            file, object_pairs_hook=OrderedDict)
                     except Exception as err:
-                        errors.append("Problem reading file %s, reason: %s" % (json_file, err))
+                        errors.append(
+                            "Problem reading file {},".format(json_file) +
+                            " reason: {}".format(err))
                     if type(candidates) != list:
                         if type(candidates) == OrderedDict:
                             data.append(candidates)
                         else:
-                            errors.append("Problem parsing data from file %s, reason: expected a list." % json_file)
+                            errors.append(
+                                "Problem parsing data from" +
+                                " file {},".format(json_file) +
+                                " reason: expected a list.")
                     else:
                         data += candidates
     return (data, errors)
@@ -126,7 +134,8 @@ class WhereAction(argparse.Action):
     """
 
     def where_test_factory(self, where_key, where_value):
-        """Wrap the where test we are using and return it as a callable function.
+        """Wrap the where test we are using and return it as a callable
+        function.
 
         item in the callback is assumed to be what we're testing against.
         """
@@ -137,17 +146,20 @@ class WhereAction(argparse.Action):
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         if not nargs:
             raise ValueError("nargs must be declared")
-        super(WhereAction, self).__init__(option_strings, dest, nargs=nargs, **kwargs)
+        super(WhereAction, self).__init__(
+            option_strings, dest, nargs=nargs, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
         try:
             where_functions = []
             for w in values:
-                where_key, where_value = w.split("=")
-                where_functions.append(self.where_test_factory(where_key, where_value))
+                w_key, w_value = w.split("=")
+                where_functions.append(self.where_test_factory(w_key, w_value))
             setattr(namespace, self.dest, where_functions)
         except Exception:
-            raise ValueError("Where options are strict. Must be in the form of 'where_key=where_value'")
+            raise ValueError(
+                "Where options are strict. Must be in the form of"
+                " 'where_key=where_value'")
 
 
 def key_counter(data, where_fn_list):
@@ -173,11 +185,12 @@ def key_counter(data, where_fn_list):
                         stats[key + '.' + subkey] += 1
 
             # If value is a list of objects, tally key.subkey for each
-            elif type(val) == list and all(type(e) == OrderedDict for e in val):
-                for obj in val:
-                    for subkey in obj.keys():
-                        if not subkey.startswith('//'):
-                            stats[key + '.' + subkey] += 1
+            elif type(val) == list:
+                if all(type(e) == OrderedDict for e in val):
+                    for obj in val:
+                        for subkey in obj.keys():
+                            if not subkey.startswith('//'):
+                                stats[key + '.' + subkey] += 1
 
             # For anything else, it only counts as one
             else:
@@ -293,7 +306,8 @@ def ui_counts_to_columns(counts):
     """Take a Counter instance and display in single fixed width key:value
     column.
     """
-    # Values in left column, counts in right, left column as wide as longest string length.
+    # Values in left column, counts in right, left
+    # column as wide as longest string length.
     key_vals = counts.most_common()
     key_field_len = len(max(list(counts.keys()), key=len)) + 1
     output_template = "%%-%ds: %%s" % key_field_len

--- a/tools/json_tools/values.py
+++ b/tools/json_tools/values.py
@@ -32,7 +32,7 @@ parser.add_argument(
 parser.add_argument(
     "-H", "--human",
     action="store_true",
-    help="if set, makes output human readable. default is to return output in JSON dictionary.")
+    help="if set, makes output human readable. default is JSON output.")
 parser.add_argument(
     "-L", "--list",
     action="store_true",

--- a/utilities/make_iso.py
+++ b/utilities/make_iso.py
@@ -20,13 +20,13 @@ import math
 
 # when a 2d sprite 'stands up' on an isometric tile bae, like a tree
 # how far up should it be from the bottom corner of the tile?
-# offset=0 will align the bottom of the sprite with the bottom (southwest corner) of the square
+# offset=0 will align bottom of sprite with bottom (SW corner) of square
 # offset<1 will be a fraction of the isometric tile height
 # offset>=1 will be an absolute number of pixels
 SPRITE_OFFSET_FROM_BOTTOM = 1.0 / 8
 
-parser = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
 
 parser.add_argument('tileset', help='name of the tileset directory to convert')
 
@@ -46,11 +46,14 @@ def iso_ize(tile_num, new_tile_num=-1, initial_rotation=0, override=False):
             new_tile_num = tile_num
         tile_png = "tile-{:0>6d}.png".format(tile_num)
         command = (
-            'convert -background transparent ' + new_tileset_name + '/tiles/' + tile_png +
+            'convert -background transparent ' +
+            new_tileset_name + '/tiles/' + tile_png +
             ' -rotate ' + str(initial_rotation) + ' ' +
             '-rotate -45 +repage -resize 100%x50% ' +
-            '-crop ' + str(nwidth) + 'x' + str(int(nwidth / 2)) + '+2+1 ' +  # TODO: get correct offsets
-            '+repage -extent ' + str(nwidth) + 'x' + str(nheight) + '+0-' + str(nheight - int(nwidth / 2)) + ' ' +
+            '-crop ' + str(nwidth) + 'x' + str(int(nwidth / 2)) +
+            '+2+1 ' +  # TODO: get correct offsets
+            '+repage -extent ' + str(nwidth) + 'x' + str(nheight) +
+            '+0-' + str(nheight - int(nwidth / 2)) + ' ' +
             new_tileset_name + '/tiles/to_merge/' + tile_png)
         print(command)
         if os.system(command):
@@ -85,6 +88,17 @@ def tile_convert(otile, main_id, new_tile_number):
                 continue
             otile[g] = list([otile[g]])
 
+        add_tile_ids = [
+            'broken',
+            'open',
+            'unconnected',
+            'center',
+            'corner',
+            'edge',
+            'end_piece',
+            't_connection',
+        ]
+
         # tile ids to iso-ify:
         # t_*.bg, .fg iff .bg is missing
         # t_*.additional_tiles.bg, .fg iff .bg is missing
@@ -97,37 +111,25 @@ def tile_convert(otile, main_id, new_tile_number):
             continue
         elif len(otile[g]) == 1:
             ntile[g] = otile[g]
+            # FIXME: These are factored out to (slightly) simplify the
+            # conditional expression below, but it still needs cleanup
+            terrain_or_lighting = isinstance(main_id, str) and (
+                main_id.startswith('t_') or main_id.startswith('lighting_'))
+            vehicle_part_or_field = isinstance(main_id, str) and (
+                main_id.startswith('vp_') or main_id.startswith('fd_'))
             # iso-ize?
             if (
-                (
-                    (main_id[0:2] == 't_' or main_id[0:9] == 'lighting_') and  # terrain and lighting
-                    (g == 'bg' or 'bg' not in otile)  # rotate bg, fg iff there's no bg
-                ) or
-                (main_id[0:2] == 'f_' and g == 'bg' and 'fg' in otile) or
-                main_id[0:3] == 'vp_' or main_id[0:3] == 'fd_' or  # vehicle parts and fields
+                (terrain_or_lighting and (g == 'bg' or 'bg' not in otile)) or
+                (main_id[0:1] == ('f_') and g == 'bg' and 'fg' in otile) or
+                vehicle_part_or_field or
                 # additional_tiles:
-                otile['id'] == 'broken' or
-                otile['id'] == 'open' or
-                otile['id'] == 'unconnected' or
-                otile['id'] == 'center' or
-                otile['id'] == 'corner' or
-                otile['id'] == 'edge' or
-                otile['id'] == 'end_piece' or
-                otile['id'] == 't_connection' or
+                otile['id'] in add_tile_ids or
                 ('rotates' in otile and otile['rotates'] is True) or
                 otile['id'] != main_id
             ):
                 # iso-ize this tile
                 iso_ize(otile[g][0], override=True)
-                if ('rotates' in otile or
-                        otile['id'] == 'broken' or
-                        otile['id'] == 'open' or
-                        otile['id'] == 'unconnected' or
-                        otile['id'] == 'center' or
-                        otile['id'] == 'corner' or
-                        otile['id'] == 'edge' or
-                        otile['id'] == 'end_piece' or
-                        otile['id'] == 't_connection'):
+                if ('rotates' in otile or otile['id'] in add_tile_ids):
                     print("  and rotating " + str(otile[g][0]))
                     # create 3 new iso-ized tiles, as well
                     for rot in (270, 180, 90):
@@ -142,11 +144,16 @@ def tile_convert(otile, main_id, new_tile_number):
                     # offset this flat tile
                     tile_png = "tile-{:0>6d}.png".format(otile[g][0])
                     command = (
-                        'convert -background transparent ' + new_tiles_dir + '/' + tile_png +
-                        (' -fill transparent -draw "color 0,0 floodfill"' if args.floodfill else '') +
+                        'convert -background transparent ' + new_tiles_dir +
+                        '/' + tile_png +
+                        (
+                            ' -fill transparent -draw "color 0,0 floodfill"'
+                            if args.floodfill else ''
+                        ) +
                         ' -extent ' + str(nwidth) + 'x' + str(nheight) +
-                        '-' + str(int((nwidth - owidth) / 2)) + '-' + str(int((nheight - oheight) - flat_sprite_offset)) + ' ' +
-                        '+repage ' + new_tiles_dir + '/to_merge/' + tile_png)
+                        '-' + str(int((nwidth - owidth) / 2)) + '-' +
+                        str(int((nheight - oheight) - flat_sprite_offset)) +
+                        ' +repage ' + new_tiles_dir + '/to_merge/' + tile_png)
                     print(command)
                     if os.system(command):
                         print("! Failed to offset %s, continuing" % tile_png)
@@ -155,7 +162,8 @@ def tile_convert(otile, main_id, new_tile_number):
             ntile[g] = otile[g]
             # iso-ize each existing rotation of this tile
             for tile in ntile[g]:
-                # if tile_num is a dict with "weight" and "sprite", take the "sprite" number
+                # if tile_num is a dict with "weight" and "sprite",
+                # take the "sprite" number
                 if type(tile) == dict and "sprite" in tile:
                     iso_ize(tile["sprite"])
                 elif type(tile) == int:
@@ -250,16 +258,22 @@ for otn in otc['tiles-new']:
     ntn['tiles'] = list()
 
     # split tile image sheet into individual tile images
-    command = 'convert -crop ' + str(oheight) + 'x' + str(owidth) + ' ' + filename + ' +repage ' + new_tiles_dir + '/tile-%06d.png'
+    command = (
+        'convert -crop ' + str(oheight) + 'x' + str(owidth) + ' ' + filename +
+        ' +repage ' + new_tiles_dir + '/tile-%06d.png')
 
     print(command)
     if os.system(command):
         raise RuntimeError("Failed to split %s into tile images" % filename)
 
-    os.system('cp ' + new_tiles_dir + '/tile-*.png ' + new_tiles_dir + '/to_merge')
+    os.system(
+        'cp ' + new_tiles_dir + '/tile-*.png ' + new_tiles_dir + '/to_merge')
 
     # path joining version for other paths
-    tile_count = len([name for name in os.listdir(new_tiles_dir) if os.path.isfile(os.path.join(new_tiles_dir, name))])
+    tile_count = len([
+        name for name in os.listdir(new_tiles_dir)
+        if os.path.isfile(os.path.join(new_tiles_dir, name))
+    ])
     new_tile_number = tile_count
 
     for otile in otn['tiles']:
@@ -271,19 +285,23 @@ for otn in otc['tiles-new']:
 
     print('Merging tiles to single image')
     command = (
-        'montage -background transparent "' + new_tileset_name + '/tiles/to_merge/tile-*.png" -tile 16x -geometry +0+0 ' +
+        'montage -background transparent "' + new_tileset_name +
+        '/tiles/to_merge/tile-*.png" -tile 16x -geometry +0+0 ' +
         new_tileset_name + '/' + base_filename)
     print(command)
     if os.system(command):
         raise RuntimeError("Failed to merge tiles into %s" % new_tileset_name)
 
-with open(new_tileset_name + '/tile_config.json', 'w') as new_tile_config_json_file:
-    json.dump(ntc, new_tile_config_json_file, sort_keys=True, indent=2, separators=(',', ': '))
+with open(new_tileset_name + '/tile_config.json', 'w') as tile_config_json:
+    json.dump(
+        ntc, tile_config_json,
+        sort_keys=True, indent=2, separators=(',', ': '))
 
 #TODO: replace tiles.png with first filename from json
 with open(new_tileset_name + '/tileset.txt', 'w') as new_tileset_txt_file:
     new_tileset_txt_file.write(
-        '#Generated by make_iso.py from flat tileset ' + old_tileset_name + '\n' +
+        '#Generated by make_iso.py from flat tileset ' +
+        old_tileset_name + '\n' +
         '#' + datetime.datetime.now().strftime('%c') + '\n' +
         '#Name of the tileset\n' +
         'NAME: ' + new_tileset_name + '\n' +


### PR DESCRIPTION
Finish reformatting our Python scripts to satisfy the PEP8 79-character line length.
