### PR TITLE
Update clang-tidy plugin docs for Windows

### DIFF
--- a/doc/DEVELOPER_TOOLING.md
+++ b/doc/DEVELOPER_TOOLING.md
@@ -141,8 +141,7 @@ lit -v build/tools/clang-tidy-plugin/test
 
 To build llvm on Windows, you'll first need to get some tools installed.
 - Cmake
-- Python 3 (Python 2 may be still required to run the lit test,
-which will be discussed in the next section.)
+- Python 3
 - MinGW-w64 (other compilers may or may not work. Clang itself does not seem to be
 building llvm on Windows correctly.)
 - A shell environment
@@ -151,14 +150,12 @@ After the tools are installed, a patch still needs to be applied before building
 llvm, since `clang-tidy` as distributed by LLVM doesn't support plugins.
 
 First, clone the llvm repo from for example [the official github repo](https://github.com/llvm/llvm-project.git).
-Checkout the `release/8.x` branch, since that's where our patch was based on.
+Checkout the `release/12.x` branch, since that's where our patch was based on.
 
 On Windows, instead of applying the patch mentioned in the previous section, you
-should apply `plugin-support.patch` from [this PR](https://github.com/jbytheway/clang-tidy-plugin-support/pull/1)
+should apply `plugin-support.patch` from [this PR](https://github.com/jbytheway/clang-tidy-plugin-support/pull/3)
 instead, if it's not merged yet. This is because the `-rdynamic` option is not
 supported on Windows, so clang-tidy needs to be built as a static library instead.
-(If you cloned the repo from the official github repo, replace `tools/extra` with
-`clang-tools-extra` in the patch before applying it.)
 
 After the patch is applied, you can then build the llvm code. Unfortunately, it
 seems that clang itself cannot correctly compile the llvm code on Windows (gives
@@ -202,7 +199,7 @@ After building clang-tidy as a library from the llvm source, the next step is to
 build clang-tidy as an executable, with the custom checks from the CDDA source.
 
 In this step, the following tools are required.
-- Python 3 (Python 2 may still be required to run the lit test for the custom checks)
+- Python 3
 - CMake
 - MinGW-w64
 - FileCheck (built from the llvm source)
@@ -221,34 +218,53 @@ be applied before the custom checks can be built as an executable.
 
 ```patch
 diff --git a/tools/clang-tidy-plugin/CMakeLists.txt b/tools/clang-tidy-plugin/CMakeLists.txt
-index 553ef0ebe0..f591bc80d1 100644
+index cf0c237645..540d3e29a5 100644
 --- a/tools/clang-tidy-plugin/CMakeLists.txt
 +++ b/tools/clang-tidy-plugin/CMakeLists.txt
-@@ -3,8 +3,8 @@ include(ExternalProject)
+@@ -4,7 +4,7 @@ include(ExternalProject)
  find_package(LLVM REQUIRED CONFIG)
  find_package(Clang REQUIRED CONFIG)
  
--add_library(
--    CataAnalyzerPlugin MODULE
-+add_executable(
-+    CataAnalyzerPlugin
-     CataTidyModule.cpp
-     JsonTranslationInputCheck.cpp
-     NoLongCheck.cpp
-@@ -51,6 +51,11 @@ else()
-         CataAnalyzerPlugin SYSTEM PRIVATE ${CATA_CLANG_TIDY_INCLUDE_DIR})
- endif()
+-add_library(CataAnalyzerPlugin MODULE
++add_executable(CataAnalyzerPlugin
+         AlmostNeverAutoCheck.cpp
+         AssertCheck.cpp
+         CataTidyModule.cpp
+@@ -56,6 +56,11 @@ else ()
+     target_include_directories(CataAnalyzerPlugin SYSTEM PRIVATE ${CATA_CLANG_TIDY_INCLUDE_DIR})
+ endif ()
  
 +target_link_libraries(
 +    CataAnalyzerPlugin
 +    clangTidyMain
 +    )
 +
- target_compile_definitions(
-     CataAnalyzerPlugin PRIVATE ${LLVM_DEFINITIONS})
+ target_compile_definitions(CataAnalyzerPlugin PRIVATE ${LLVM_DEFINITIONS})
  
+ # We need to turn off exceptions and RTTI to match the LLVM build.
+diff --git a/tools/clang-tidy-plugin/CataTidyModule.cpp b/tools/clang-tidy-plugin/CataTidyModule.cpp
+index b7cb4df22c..a83db0c60e 100644
+--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
++++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
+@@ -18,6 +18,7 @@
+ #include "TestFilenameCheck.h"
+ #include "TestsMustRestoreGlobalStateCheck.h"
+ #include "TextStyleCheck.h"
++#include "tool/ClangTidyMain.h"
+ #include "TranslatorCommentsCheck.h"
+ #include "UnsequencedCallsCheck.h"
+ #include "UnusedStaticsCheck.h"
+@@ -80,3 +81,8 @@ X( "cata-module", "Adds Cataclysm-DDA checks." );
+ 
+ } // namespace tidy
+ } // namespace clang
++
++int main( int argc, const char **argv )
++{
++    return clang::tidy::clangTidyMain( argc, argv );
++}
 diff --git a/tools/clang-tidy-plugin/test/lit.cfg b/tools/clang-tidy-plugin/test/lit.cfg
-index 4ab6e913a7..d1a4418ba6 100644
+index 496804316a..43beb49653 100644
 --- a/tools/clang-tidy-plugin/test/lit.cfg
 +++ b/tools/clang-tidy-plugin/test/lit.cfg
 @@ -17,11 +17,13 @@ else:
@@ -271,12 +287,10 @@ index 4ab6e913a7..d1a4418ba6 100644
 The next step is to run CMake to generate the compilation database. The compilation
 database contains compiler flags that clang-tidy uses to check the source files.
 
-Make sure Python 3 (and Python 2 if it's still required), CMake, MinGW-w64, and FileCheck are on the path.
+Make sure Python 3, CMake, MinGW-w64, and FileCheck are on the path.
 Note that two `bin` directories of MinGW-w64 should be on the path: `<mingw-w64-root>/bin`,
 and `<mingw-w64-root>/x86_64-w64-mingw32/bin`. FileCheck's path is `<llvm-source-root>/build/bin`,
-if you built it with the instructions in the previous section. Python 2 should
-precede Python 3 in the path, otherwise scripts that are intended to run with
-Python 2 might not work.
+if you built it with the instructions in the previous section.
 
 Then add the following CMake options to generate the compilation database
 (substitute values inside `<>` with the actual paths) and build the CDDA source
@@ -299,10 +313,10 @@ with Python 3 to fix some errors in the compilation database. Then the compilati
 database should be usable by clang-tidy.
 
 If you want to check if the custom checks are working correctly, run the following
-script. Note that `python` here is the executable from Python 2.
+script.
 
 ```sh
-python <llvm-source-root>/llvm/utils/lit/lit.py -v build/tools/clang-tidy-plugin/test
+python3 <llvm-source-root>/llvm/utils/lit/lit.py -v build/tools/clang-tidy-plugin/test
 ```
 
 Finally, use the following command to run clang-tidy with the custom checks.


### PR DESCRIPTION
This is the updated workflow for building the clang tidy plugin with LLVM 12 on Windows (https://github.com/CleverRaven/Cataclysm-DDA/pull/48739).